### PR TITLE
Make setting settings more robust

### DIFF
--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -42,9 +42,9 @@ class Bullwinkle {
     constructor(settings = {}) {
         // Initialize settings
         _settings = {
-            "messageTimeout":   ("messageTimeout" in settings) ? settings["messageTimeout"].tointger() : 10,
-            "retryTimeout":     ("retryTimeout" in settings) ? settings["retryTimeout"].tointger() : 60,
-            "maxRetries":       ("maxRetries" in settings) ? settings["maxRetries"] : 0,
+            "messageTimeout":   ("messageTimeout" in settings) ? settings["messageTimeout"].tostring().tointeger() : 10,
+            "retryTimeout":     ("retryTimeout" in settings) ? settings["retryTimeout"].tostring().tointeger() : 60,
+            "maxRetries":       ("maxRetries" in settings) ? settings["maxRetries"].tostring().tointeger() : 0,
         };
 
         // Initialize out message handlers


### PR DESCRIPTION
Fixes a typo (".tointger" -> ".tointeger").  Adds .tostring() before .tointeger() to allow passing values of type integer as well as string (calling ".tointeger()" on an integer throws an error).
