### PR TITLE
Better partition Bullwinkle.Package and bullwinkle messages sent "over the wire"

### DIFF
--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -52,7 +52,8 @@ class Bullwinkle {
             "retryTimeout":       ("retryTimeout" in settings) ? settings["retryTimeout"].tostring().tointeger() : 60,
             "maxRetries":         ("maxRetries" in settings) ? settings["maxRetries"].tostring().tointeger() : 0,
             "autoRetry" :	        ("autoRetry" in settings) ? settings["autoRetry"] : false,
-            "lowMemoryThreshold": ("lowMemoryThreshold" in settings) ? settings["lowMemoryThreshold"] : 15000,
+            "lowMemoryThreshold": ("lowMemoryThreshold" in settings) ? settings["lowMemoryThreshold"].tointeger() : 15000,
+            "firstMessageID":     ("firstMessageID" in settings) ? settings["firstMessageID"].tointeger() : 0
             "onError" :           ("onError" in settings) ? settings["onError"] : null
         };
 
@@ -62,8 +63,8 @@ class Bullwinkle {
         // Initialize list of packages
         _packages = {};
 
-        // Initialize the ID counter
-        _nextId = 0;
+        // Initialize the ID counter (can be set to math.rand() or the last message ID you have in nv to prevent ID collisions with something like impPager)
+        _nextId = settings.firstMessageID;
 
         // Setup the agent/device.on handler
         _partner = _isAgent() ? device : agent;

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -96,10 +96,11 @@ class Bullwinkle {
     // Parameters:
     //      name            The message name
     //      data            Optional data
+    //      ts              Optional timestamp for the data
     //
-    // Returns:             Rocky.Package object
-    function send(name, data = null) {
-        local message = _messageFactory(BULLWINKLE_MESSAGE_TYPE.SEND, name, data);
+    // Returns:             Bullwinkle.Package object
+    function send(name, data = null, ts = null) {
+        local message = _messageFactory(BULLWINKLE_MESSAGE_TYPE.SEND, name, data, ts);
         local package = Bullwinkle.Package(message);
         _packages[message.id] <- package;
         _sendMessage(message);
@@ -435,7 +436,7 @@ class Bullwinkle {
             }
 
             // if it's a message awaiting a reply
-            local ts = "retry" in message ? message.retry.ts : message.ts;
+            local ts = "retry" in message ? message.retry.ts : split(package._ts, "."); //Use either the retry ts or the package ts, but NOT the message ts so that it can be set for whenever the data was generated, instead of when Bullwinkle attempted to send it
             if (t >= (ts + _settings.messageTimeout)) {
                 // Grab the onFail handler
                 local handler = package.getHandler("onFail");

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -50,6 +50,7 @@ class Bullwinkle {
             "retryTimeout":     ("retryTimeout" in settings) ? settings["retryTimeout"].tostring().tointeger() : 60,
             "maxRetries":       ("maxRetries" in settings) ? settings["maxRetries"].tostring().tointeger() : 0,
             "autoRetry" :	("autoRetry" in settings) ? settings["autoRetry"] : false,
+            "prependID" : ("prependID" in settings) ? settings["prependID"].tostring() + "|" : ""
             "onError" : ("onError" in settings) ? settings["onError"] : null
         };
 
@@ -122,7 +123,7 @@ class Bullwinkle {
     function _generateId() {
         // Get the next ID
         while (++_nextId in _packages) {
-            _nextId = (_nextId + 1) % RAND_MAX;
+            _nextId = _settings.prependID + ((_nextId + 1) % RAND_MAX);
         }
 
         // Return the generated ID

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -50,7 +50,6 @@ class Bullwinkle {
             "retryTimeout":     ("retryTimeout" in settings) ? settings["retryTimeout"].tostring().tointeger() : 60,
             "maxRetries":       ("maxRetries" in settings) ? settings["maxRetries"].tostring().tointeger() : 0,
             "autoRetry" :	("autoRetry" in settings) ? settings["autoRetry"] : false,
-            "prependID" : ("prependID" in settings) ? settings["prependID"].tostring() + "|" : ""
             "onError" : ("onError" in settings) ? settings["onError"] : null
         };
 
@@ -124,7 +123,7 @@ class Bullwinkle {
     function _generateId() {
         // Get the next ID
         while (++_nextId in _packages) {
-            _nextId = _settings.prependID + ((_nextId + 1) % RAND_MAX);
+            _nextId = (_nextId + 1) % RAND_MAX;
         }
 
         // Return the generated ID

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -21,7 +21,7 @@ const BULLWINKLE_WATCHDOG_TIMER = 0.5;
 
 
 class Bullwinkle {
-    static version = [2,3,1];
+    static version = [2,3,2];
 
     // The bullwinkle message
     static BULLWINKLE = "bullwinkle";

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -166,7 +166,7 @@ class Bullwinkle {
 		        _packages[message.id]._tries++;
         }
 
-        if(server.isconnected()) // Send the message
+        if(_isAgent() || server.isconnected()) // Send the message
           _partner.send(BULLWINKLE, message);
         else if(message.id in _packages)  //run the timeout flow (if the package exists)
           imp.wakeup(0, function(){ // on the next tick so that the onFail handler can have a chance to register itself

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -173,9 +173,11 @@ class Bullwinkle {
           _partner.send(BULLWINKLE, message); // Send the message
         } else if(message.id in _packages){ //run the failure flow (if the package exists)
           local reason = imp.getmemoryfree() <= _settings.lowMemoryThreshold ? BULLWINKLE_ERR_LOW_MEMORY : BULLWINKLE_ERR_NO_CONNECTION
-          imp.wakeup(0, function(){ // run on the "next tick" so that the onFail handler can have a chance to register itself
-            _packageFailed(_packages[message.id], reason)
-          }.bindenv(this))
+
+          local timer = imp.wakeup(0.0, function(){ // run on the "next tick" so that the onFail handler can have a chance to register itself
+              _packageFailed(_packages[message.id], reason)
+          }.bindenv(this));
+          _checkTimer(timer)
         }
     }
 
@@ -438,7 +440,7 @@ class Bullwinkle {
         }
     }
 
-    // checks that TIMER was set, calles onError callback if needed
+    // checks that TIMER was set, calls onError callback if needed
     //
     // Parameters:
     //      timer         The value returned by calling imp.wakeup

--- a/Bullwinkle.class.nut
+++ b/Bullwinkle.class.nut
@@ -99,7 +99,7 @@ class Bullwinkle {
     // Parameters:
     //      name            The message name
     //      data            Optional data
-    //      ts              Optional timestamp for the data
+    //      ts              Optional timestamp for the data 
     //
     // Returns:             Bullwinkle.Package object
     function send(name, data = null, ts = null) {
@@ -343,7 +343,7 @@ class Bullwinkle {
             handler(BULLWINKLE_ERR_NO_HANDLER, message, retry);
 
             // Delete the message if the dev didn't retry
-            if (message.type == BULLWINKLE_MESSAGE_TYPE.NACK) {
+            if (message.type == BULLWINKLE_MESSAGE_TYPE.NACK && message.id in __bull.packages) {
             	delete __bull._packages[message.id];
             }
         });


### PR DESCRIPTION
This set of commits provides better partitioning between the role of the Bullwinkle.Package (stored in the sending party's RAM) and the message that is actually sent between agent/device.

The main driver behind this is to allow custom timestamps to be sent with each message.  Before, Bullwinkle relied on the message.ts for its internal timeout logic.  Now, message.ts can be set to whenever the message was originally generated (say before it was written to spiflash) and Bullwinkle.Package._ts is used for the watchdog, etc.

I've not done a substantial amount of testing (are there any impTests for this lib?) but the update appears to generally be working for me...  The README has also yet to be updated with the optional ts value in .send()
